### PR TITLE
Add insert_medical_record API

### DIFF
--- a/pages/api/add_medical_record.js
+++ b/pages/api/add_medical_record.js
@@ -63,19 +63,18 @@ export default async function handler(req, res) {
     }
     // Tạo appointment id mới
     let appoint_id;
-    try{
+    try {
         appoint_id = await countAppointID(db);
         appoint_id++;
-    }
-    catch (err){
+    } catch (err) {
         db.close();
         return res.status(403).json({message: "FAIL: Cannot connect to database"});
     }
     // Insert new record
     try {
-        let data = [appoint_id, "waiting" ,p_id, req.body["d_id"]];
+        let data = [appoint_id, "waiting", p_id, req.body["d_id"]];
         await insertAppointment(db, data);
-    }catch (err){
+    } catch (err) {
         db.close();
         return res.status(403).json({message: "FAIL: Cannot connect to database"});
     }
@@ -93,19 +92,14 @@ export default async function handler(req, res) {
     }
     // Insert vào RECORD table
     try {
-        let date = new Date();
-        let month = date.getMonth() + 1;
-        // Ngày tạo hồ sơ bệnh án
-        let rec_date = parseInt("" + date.getDate() + month + date.getFullYear());
-
-        let data = [new_rec_id, rec_date, rec_date, req.body["rec_dease"]
+        let data = [new_rec_id, req.body["rec_dease"]
             , req.body["rec_indiagnose"], req.body["rec_outdiagnose"],
             req.body["rec_desc"], req.body["rec_conclusion"], req.body["rec_examineday"],
             req.body["rec_reexamineday"], appoint_id];
         await insertRecord(db, data);
         return res.status(200).json({message: "SUCCESS"});
     } catch (err) {
-        return res.status(403).json({message: "FAIL"});
+        return res.status(403).json({message: err});
     } finally {
         db.close();
     }
@@ -195,7 +189,7 @@ function countRecID(db) {
 
 function insertRecord(db, data) {
     return new Promise((resolve, reject) => {
-        db.run("INSERT INTO RECORD VALUES(?,?,?,?,?,?,?,?,?,?,?)", data, (err) => {
+        db.run("INSERT INTO RECORD VALUES(?, strftime('%Y-%m-%d', 'now'), strftime('%Y-%m-%d', 'now'), ?, ?, ?, ?, ?, ?, ?, ?)", data, (err) => {
             if (err) {
                 reject(err);
             }

--- a/pages/api/add_medical_record.js
+++ b/pages/api/add_medical_record.js
@@ -19,7 +19,7 @@ export default async function handler(req, res) {
     // Mở kết nối với database
     const db = new sqlite3.Database("./database.sqlite", sqlite3.OPEN_READWRITE, (err) => {
         if (err) {
-            return res.status(403).json({message: "FAIL: Cannot connect to database"});
+            return res.status(403).json({message: "FAIL: Cannot connect to database1"});
         }
     });
     // Kiểm tra p_id có tồn tại trong request lẫn database không
@@ -47,7 +47,7 @@ export default async function handler(req, res) {
             await insertPatient(db, data);
         } catch (err) {
             db.close();
-            return res.status(403).json({message: "FAIL: Cannot connect to database"});
+            return res.status(403).json({message: "FAIL: Cannot connect to database2"});
         }
     } else {
         let data = [req.body["p_dateOB"],
@@ -57,19 +57,27 @@ export default async function handler(req, res) {
 
         } catch (err) {
             db.close();
-            return res.status(403).json({message: "FAIL: Cannot connect to database"});
+            return res.status(403).json({message: "FAIL: Cannot connect to database3"});
         }
 
     }
-    // Tạo appointment mới
-    let appoint_id = await countAppointID(db);
-    appoint_id++;
+    // Tạo appointment id mới
+    let appoint_id;
+    try{
+        appoint_id = await countAppointID(db);
+        appoint_id++;
+    }
+    catch (err){
+        db.close();
+        return res.status(403).json({message: "FAIL: Cannot connect to database4"});
+    }
+    // Insert new record
     try {
-        let data = [appoint_id, p_id, req.body["d_id"]];
+        let data = [appoint_id, "waiting" ,p_id, req.body["d_id"]];
         await insertAppointment(db, data);
     }catch (err){
         db.close();
-        return res.status(403).json({message: "FAIL: Cannot connect to database"});
+        return res.status(403).json({message: err});
     }
 
 
@@ -81,7 +89,7 @@ export default async function handler(req, res) {
         new_rec_id++;
     } catch (err) {
         db.close();
-        return res.status(403).json({message: "FAIL: Cannot connect to database"});
+        return res.status(403).json({message: "FAIL: Cannot connect to database6"});
     }
     // Insert vào RECORD table
     try {
@@ -97,7 +105,7 @@ export default async function handler(req, res) {
         await insertRecord(db, data);
         return res.status(200).json({message: "SUCCESS"});
     } catch (err) {
-        return res.status(403).json({message: "FAIL: Cannot connect to database"});
+        return res.status(403).json({message: "FAIL"});
     } finally {
         db.close();
     }
@@ -142,7 +150,7 @@ function updatePatient(db, data, p_id) {
 
 function insertAppointment(db, data) {
     return new Promise((resolve, reject) => {
-        db.run("INSERT INTO APPOINTMENT(appoint_id, p_id, d_id) VALUES(?, ?, ?)", data, (err) => {
+        db.run("INSERT INTO APPOINTMENT(appoint_id, appoint_status, p_id, d_id) VALUES(?, ?, ?, ?)", data, (err) => {
             if (err) {
                 reject(err);
             }

--- a/pages/api/add_medical_record.js
+++ b/pages/api/add_medical_record.js
@@ -88,7 +88,7 @@ export default async function handler(req, res) {
         new_rec_id++;
     } catch (err) {
         db.close();
-        return res.status(403).json({message: "FAIL: Cannot connect to database6"});
+        return res.status(403).json({message: "FAIL: Cannot connect to database"});
     }
     // Insert vào RECORD table
     try {
@@ -99,7 +99,7 @@ export default async function handler(req, res) {
         await insertRecord(db, data);
         return res.status(200).json({message: "SUCCESS"});
     } catch (err) {
-        return res.status(403).json({message: err});
+        return res.status(403).json({message: "FAIL: Cannot connect to database"});
     } finally {
         db.close();
     }

--- a/pages/api/add_medical_record.js
+++ b/pages/api/add_medical_record.js
@@ -19,7 +19,7 @@ export default async function handler(req, res) {
     // Mở kết nối với database
     const db = new sqlite3.Database("./database.sqlite", sqlite3.OPEN_READWRITE, (err) => {
         if (err) {
-            return res.status(403).json({message: "FAIL: Cannot connect to database1"});
+            return res.status(403).json({message: "FAIL: Cannot connect to database"});
         }
     });
     // Kiểm tra p_id có tồn tại trong request lẫn database không
@@ -47,7 +47,7 @@ export default async function handler(req, res) {
             await insertPatient(db, data);
         } catch (err) {
             db.close();
-            return res.status(403).json({message: "FAIL: Cannot connect to database2"});
+            return res.status(403).json({message: "FAIL: Cannot connect to database"});
         }
     } else {
         let data = [req.body["p_dateOB"],
@@ -57,7 +57,7 @@ export default async function handler(req, res) {
 
         } catch (err) {
             db.close();
-            return res.status(403).json({message: "FAIL: Cannot connect to database3"});
+            return res.status(403).json({message: "FAIL: Cannot connect to database"});
         }
 
     }
@@ -69,7 +69,7 @@ export default async function handler(req, res) {
     }
     catch (err){
         db.close();
-        return res.status(403).json({message: "FAIL: Cannot connect to database4"});
+        return res.status(403).json({message: "FAIL: Cannot connect to database"});
     }
     // Insert new record
     try {
@@ -77,7 +77,7 @@ export default async function handler(req, res) {
         await insertAppointment(db, data);
     }catch (err){
         db.close();
-        return res.status(403).json({message: err});
+        return res.status(403).json({message: "FAIL: Cannot connect to database"});
     }
 
 

--- a/pages/api/add_medical_record.js
+++ b/pages/api/add_medical_record.js
@@ -1,0 +1,168 @@
+import sqlite3 from "sqlite3";
+
+export default async function handler(req, res) {
+    // Kiểm tra method của req
+    // Chỉ chấp nhận method POST
+    if (req.method !== "POST") {
+        return res.status(405).json({message: `FAIL: The request method must be POST, got ${req.method} instead`});
+    }
+    // Kiểm tra req có những field hợp lệ hay không
+    //  Không thể được thiếu dù chỉ 1 field
+    const requiredFields = ["p_id", "rec_dease", "p_dateOB", "p_sex", "p_ethnic", "p_BHXH",
+        "p_address", "rec_indiagnose", "rec_outdiagnose",
+        "rec_desc", "rec_conclusion", "rec_examineday", "rec_reexamineday"];
+    for (let field of requiredFields) {
+        if (!req.body.hasOwnProperty(field)) {
+            return res.status(403).json({message: `FAIL: The request body does not have ${field} field`});
+        }
+    }
+    // Mở kết nối với database
+    const db = new sqlite3.Database("./database.sqlite", sqlite3.OPEN_READWRITE, (err) => {
+        if (err) {
+            return res.status(403).json({message: "FAIL: Cannot connect to database"});
+        }
+    });
+
+    let checkPid;
+    try {
+        checkPid = await checkPatientRecord(db, req.body["p_id"]);
+    } catch (err) {
+        db.close();
+        return res.status(403).json({message: "FAIL"});
+    }
+    if (checkPid === 0) {
+        let data = [req.body["p_id"], req.body["p_dateOB"],
+            req.body["p_sex"], req.body["p_ethnic"], req.body["p_BHXH"], req.body["p_address"]];
+        try {
+            await insertPatient(db, data);
+        } catch (err) {
+            db.close();
+            return res.status(403).json({message: "FAIL: Cannot connect to database"});
+        }
+    } else {
+        let data = [req.body["p_dateOB"],
+            req.body["p_sex"], req.body["p_ethnic"], req.body["p_BHXH"], req.body["p_address"]];
+        try {
+            await updatePatient(db, data, req.body["p_id"]);
+
+        } catch (err) {
+            db.close();
+            return res.status(403).json({message: "FAIL: Cannot connect to database"});
+        }
+
+    }
+    // Kiểm tra appoint id trong bảng APPOINTMENT
+    // Vì bảng record cần appoint id là khóa ngoại trỏ tới bảng APPOINTMENT
+    // Hơn nữa appoint id là field not null -> nếu không tìm thấy thì báo lỗi
+    let appoint_id;
+    try {
+        appoint_id = await getAppointID(db, req.body["p_id"])
+        if (appoint_id === null) {
+            db.close();
+            return res.status(403).json({
+                message: "FAIL: Cannot find the appoint id in APPOINTMENT " + "table corresponding to request p_id"
+            });
+        }
+    } catch (err) {
+        db.close();
+        return res.status(403).json({message: err});
+    }
+    // Thuật toán gán rec_id của API: tính số record có trong table RECORD
+    // Sau đó lấy COUNT(*) + 1 = id cho record mới này
+    let new_rec_id;
+    try {
+        new_rec_id = await countRecID(db);
+        new_rec_id++;
+    } catch (err) {
+        db.close();
+        return res.status(403).json({message: "FAIL: Cannot connect to database"});
+    }
+    // Insert vào RECORD table
+    try {
+        let date = new Date();
+        let month = date.getMonth() + 1;
+        // Ngày tạo hồ sơ bệnh án
+        let rec_date = parseInt("" + date.getDate() + month + date.getFullYear());
+
+        let data = [new_rec_id, rec_date, rec_date, req.body["rec_dease"]
+            , req.body["rec_indiagnose"], req.body["rec_outdiagnose"],
+            req.body["rec_desc"], req.body["rec_conclusion"], req.body["rec_examineday"],
+            req.body["rec_reexamineday"], appoint_id];
+        await insertRecord(db, data);
+        return res.status(200).json({message: "SUCCESS"});
+    } catch (err) {
+        return res.status(403).json({message: "FAIL: Cannot connect to database"});
+    } finally {
+        db.close();
+    }
+    // Nếu thành công thì chương trình sẽ không thể thực thi tới đây do đã return trong khối try catch
+    // Nếu tới đây thì nghĩa đoạn code bị lỗi -> return res status 500 internal error
+    return res.status(500).json({message: "FAIL"}).end();
+}
+
+function checkPatientRecord(db, p_id) {
+    return new Promise((resolve, reject) => {
+        db.all("SELECT COUNT(*) FROM patient WHERE p_id = " + p_id, (err, row) => {
+            if (err) {
+                reject(err);
+            }
+            resolve(row[0]["COUNT(*)"]);
+        })
+    });
+}
+
+function insertPatient(db, data) {
+    return new Promise((resolve, reject) => {
+        db.run("INSERT INTO PATIENT(p_id, p_dateOB, p_sex, p_ethnic, p_BHXH, p_address) VALUES(?, ?, ?, ?, ?, ?)", data, (err) => {
+            if (err) {
+                reject(err);
+            }
+            resolve();
+        });
+    });
+}
+
+function updatePatient(db, data, p_id) {
+    return new Promise((resolve, reject) => {
+        db.run("UPDATE PATIENT SET p_dateOB = ? , p_sex = ? ,p_ethnic = ?, p_BHXH = ?" +
+            ", p_address = ? WHERE p_id = " + p_id, (err) => {
+            if (err) {
+                reject(err);
+            }
+            resolve();
+        });
+    });
+}
+
+function getAppointID(db, p_id) {
+    return new Promise((resolve, reject) => {
+        db.all("SELECT appoint_id FROM APPOINTMENT WHERE p_id = " + p_id, (err, rows) => {
+            if (err) {
+                reject(err);
+            }
+            resolve((rows[0]) ? (rows[0]["appoint_id"]) : null);
+        })
+    });
+}
+
+function countRecID(db) {
+    return new Promise((resolve, reject) => {
+        db.all("SELECT COUNT(*) FROM RECORD", (err, row) => {
+            if (err) {
+                reject(err);
+            }
+            resolve(row[0]["COUNT(*)"]);
+        })
+    });
+}
+
+function insertRecord(db, data) {
+    return new Promise((resolve, reject) => {
+        db.run("INSERT INTO RECORD VALUES(?,?,?,?,?,?,?,?,?,?,?)", data, (err) => {
+            if (err) {
+                reject(err);
+            }
+            resolve();
+        });
+    });
+}

--- a/pages/api/medical_record.js
+++ b/pages/api/medical_record.js
@@ -34,15 +34,15 @@ export default async function handler(req, res) {
     return res.status(500).json({message: "FAIL"}).end();
 }
 
+
 function retrieveData(db, id) {
     return new Promise((resolve, reject) => {
         let queryResult = [];
         // Query với cú pháp của sqlite3 (MySQL)
-        // ID, tên bệnh nhân, giới tính, ngày sinh, email
         let sql = "SELECT * FROM RECORD WHERE rec_id = " + id;
         db.all(sql, (err, rows) => {
             if (err) {
-                resolve(err);
+                reject(err);
             }
             // Mỗi element trong array queryResult sẽ chứa 1 JSON về 1 medical record cùng rec_id (mặc dù rec_id là unique)
             rows.forEach((row) => {


### PR DESCRIPTION
request cần có: ["d_id", "rec_dease", "p_dateOB", "p_sex", "p_ethnic", "p_BHXH", 
     "p_address", "rec_indiagnose", "rec_outdiagnose",
        "rec_desc", "rec_conclusion", "rec_examineday", "rec_reexamineday"]

Nếu p_id chưa có / undefined trong request thì tự động tạo mới p_id và insert record mới vào PATIENT table
Nếu p_id đã có thì update record với p_id tương ứng và thông tin trong request

Tạo appointment mới trong APPOINTMENT table dựa vào p_id và d_id
appoint_status mặc định luôn là waiting

Thuật toán tạo rec_id mới của API: lấy tổng số record đang có trong table RECORD + 1 = rec_id mới

Field "ngày khởi tạo" (rec_date) và "ngày chỉnh sửa lần cuối" (rec_lastmodified) trong RECORD là hôm nay (sử dụng hàm strftime('%Y-%m-%d', 'now') trong sqlite)

response: thành công {message: success}
response: thất bại {message: FAIL} kèm ghi chú lỗi